### PR TITLE
Implement ignore 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,21 +34,32 @@ A rebar plugin to update dependencies
 Usage: rebar3 update-deps [-r [<replace>]] [-c [<rebar_config>]]
                           [-a [<update_approx>]] [-d [<just_deps>]]
                           [-p [<just_plugins>]] [-h [<just_hex>]]
+                          [-i <ignore>]
 
-  -r, --replace        Directly replace values in rebar.config. The
-                       default is to just show you what deps can be
-                       updated because this is an experimental feature and
-                       using it can mess up your formatting and comments.
+  -r, --replace        Directly replace values in rebar.config. The 
+                       default is to just show you what deps can be 
+                       updated because this is an experimental feature and 
+                       using it can mess up your formatting and comments. 
                        [default: false]
   -c, --rebar-config   File to analyze [default: rebar.config]
-  -a, --update-approx  Update requirements starting with '~>' as well as
+  -a, --update-approx  Update requirements starting with '~>' as well as 
                        the ones with a specific version. [default: true]
-  -d, --just-deps      Only update deps (i.e. ignore plugins and
+  -d, --just-deps      Only update deps (i.e. ignore plugins and 
                        project_plugins). [default: false]
-  -p, --just-plugins   Only update plugins and project_plugins (i.e.
+  -p, --just-plugins   Only update plugins and project_plugins (i.e. 
                        ignore deps). [default: false]
-  -h, --just-hex       Only update hex packages, ignore git repos.
+  -h, --just-hex       Only update hex packages, ignore git repos. 
                        [default: false]
+  -i, --ignore         Ignore dep when updating (can be repeated).
+```
+
+## Configuration
+
+To automatically ignore updates for one or more deps, add the `ignore` configuration to your `rebar.config`:
+
+```erlang
+%% Ignore any updates for eredis and lager.
+{depup, [{ignore, [eredis, lager]}]}.
 ```
 
 ## Build

--- a/src/dep_updater.erl
+++ b/src/dep_updater.erl
@@ -17,9 +17,25 @@
 %%      semver requirements and all deps linked to a particular tag in a git repository.</p>
 %%      <p>If <code>#{just_hex := true} = Opts</code>, it only checks pacakges from hex.pm.</p>
 %%      <p>If <code>#{update_approx := false} = Opts</code>, it only check exact versions.</p>
+%%      <p>If <code>#{ignore := [atom,...]} = Opts</code>, the specified deps won't be updated.</p>
 -spec update(deps(), opts()) -> deps().
 update(Deps, Opts) ->
-    [update_dep(Dep, Opts) || Dep <- Deps].
+    DepsToIgnore = maps:get(ignore, Opts),
+    lists:map(fun(Dep) ->
+                 Name = dep_name(Dep),
+                 case proplists:lookup(Name, DepsToIgnore) of
+                     none ->
+                         update_dep(Dep, Opts);
+                     _Ignored ->
+                         Dep
+                 end
+              end,
+              Deps).
+
+dep_name(Dep) when is_tuple(Dep) ->
+    element(1, Dep);
+dep_name(Dep) when is_atom(Dep) ->
+    Dep.
 
 %% @see rebar_app_utils:parse_dep/5.
 update_dep(Dep = {_, _, {pkg, _}}, Opts) ->

--- a/src/rebar3_depup_prv.erl
+++ b/src/rebar3_depup_prv.erl
@@ -47,7 +47,8 @@ opts() ->
       $h,
       "just-hex",
       {boolean, false},
-      "Only update hex packages, ignore git repos."}].
+      "Only update hex packages, ignore git repos."},
+     {ignore, $i, "ignore", atom, "Ignore dep when updating (can be repeated)."}].
 
 %% @private
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()}.
@@ -86,12 +87,16 @@ format_error(Reason) ->
 
 parse_opts(State) ->
     {Args, _} = rebar_state:command_parsed_args(State),
+    IgnoreList =
+        lists:usort(proplists:get_all_values(ignore, Args)
+                    ++ proplists:get_value(ignore, rebar_state:get(State, depup, []), [])),
     #{replace => proplists:get_value(replace, Args),
       rebar_config => proplists:get_value(rebar_config, Args),
       update_approx => proplists:get_value(update_approx, Args),
       just_deps => proplists:get_value(just_deps, Args),
       just_plugins => proplists:get_value(just_plugins, Args),
-      just_hex => proplists:get_value(just_hex, Args)}.
+      just_hex => proplists:get_value(just_hex, Args),
+      ignore => IgnoreList}.
 
 update_deps(Config, State, Opts) ->
     update_deps(Config, default, State, Opts).

--- a/test/ignore.config
+++ b/test/ignore.config
@@ -1,0 +1,12 @@
+{erl_opts, [debug_info]}.
+
+{deps,
+ [{recon, "0.0.1"},
+  {redbug, {pkg, redbug}},
+  {spillway, {git, "https://github.com/AdRoll/spillway.git", {tag, "v0.0.1"}}}]}.
+
+{project_plugins,
+ [{rebar3_format, "~> 0.0.1"},
+  {rebar3_hank, {git, "https://github.com/AdRoll/rebar3_hank.git", {tag, "0.0.1"}}}]}.
+
+{plugins, [{rebar3_proper, "0.0.1"}]}.

--- a/test/ignore_config.config
+++ b/test/ignore_config.config
@@ -1,0 +1,14 @@
+{erl_opts, [debug_info]}.
+
+{deps,
+ [{recon, "0.0.1"},
+  {redbug, {pkg, redbug}},
+  {spillway, {git, "https://github.com/AdRoll/spillway.git", {tag, "v0.0.1"}}}]}.
+
+{project_plugins,
+ [{rebar3_format, "~> 0.0.1"},
+  {rebar3_hank, {git, "https://github.com/AdRoll/rebar3_hank.git", {tag, "0.0.1"}}}]}.
+
+{plugins, [{rebar3_proper, "0.0.1"}]}.
+
+{depup, [{ignore, [spillway]}]}.


### PR DESCRIPTION
Implements ignore, with the additional option of ignoring a dep with the `-i/--ignore` command line argument.

Summary of changes: 
* `rebar3_depup_prv.erl` now recognizes the `-I/--ignore` flag and creates a list of dep names to ignore, if any
* `rebar3_depup_prv.erl` now appends any configured ignored deps to the above list, if any
* `dep_updater.erl` will skip any configured dep to ignore and return it as-is 
* `depup_SUITE.erl` is updated to handle configs, and tests are added for both config and command line ignoring
* `README.md` has updated documentation
* new test config files added: `ignore.config` and `ignore_config.config`

Closes #3.
