### PR TITLE
Output (visible) message in case of error

### DIFF
--- a/src/dep_updater.erl
+++ b/src/dep_updater.erl
@@ -86,7 +86,7 @@ maybe_update_git_dep(Name, {git, Repo, {tag, Vsn}}, _Dep, Opts) ->
             io_lib:format("git -c 'versionsort.suffix=-' ls-remote --refs --tags ~p '*.*.*'",
                           [Repo])),
     LatestVsn =
-        case rebar_utils:sh(GitCmd, []) of
+        case rebar_utils:sh(GitCmd, [use_stdout]) of
             {ok, ""} ->
                 rebar_api:info("Latest version for ~p not found, keeping ~ts", [Name, Vsn]),
                 Vsn;


### PR DESCRIPTION
Fix #30.

As-is, trying to fetch from an unreachable repository will end abruptly, with no output error message, as so

```
➜  bug ✗ rebar3 update-deps
===> Analyzing applications...
===> Compiling rebar3_depup
===> Looking for dependencies to update in rebar.config...
===> cowboy can be updated from 2.8.0 to 2.9.0
➜  bug ✗
```

Using `DIAGNOSTIC=1 rebar3 update-deps` on the other hand, will output more useful information, but that flag tends to be used in case of error, which is not shown (at first I was even thinking everything was Ok with my deps).

The current pull request proposes more visible output in the form of

```
➜  bug ✗ rebar3 update-deps
===> Analyzing applications...
===> Compiling rebar3_depup
===> Looking for dependencies to update in rebar.config...
===> cowboy can be updated from 2.8.0 to 2.9.0
failed with return code 128 and the following output:
ssh: connect to host <HOST> port <PORT>: Network is unreachable
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
➜  bug ✗
```